### PR TITLE
Update NanoPi-R1s H5 OpenWrt 19.07 Build.yml

### DIFF
--- a/.github/workflows/NanoPi-R1s H5 OpenWrt 19.07 Build.yml
+++ b/.github/workflows/NanoPi-R1s H5 OpenWrt 19.07 Build.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Update Target.mk
         run: |
           cd friendlywrt-h5/friendlywrt/include 
-          sed -i 's/dnsmasq /dnsmasq-full default-settings luci/' target.mk    
+          sed -i 's/dnsmasq /dnsmasq-full default-settings luci /' target.mk    
           
       - name: Update Feeds
         run: |


### PR DESCRIPTION
少了个空格，luci和dnsmasq之后的包名会连在一起，
补一下